### PR TITLE
Flutter: add account to initiate handshake

### DIFF
--- a/flutter/.vscode/settings.json
+++ b/flutter/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "workbench.colorTheme": "Solarized Light"
+}

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -47,6 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.coinbase:coinbase-wallet-sdk:0.1.0"
+    implementation "com.coinbase:coinbase-wallet-sdk:0.2.1"
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -47,6 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.coinbase:coinbase-wallet-sdk:0.2.1"
+    implementation "com.coinbase:coinbase-wallet-sdk:0.3.0"
     implementation 'com.google.code.gson:gson:2.9.1'
 }

--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -75,5 +75,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "com.coinbase:coinbase-wallet-sdk:0.2.1"
+    implementation "com.coinbase:coinbase-wallet-sdk:0.3.0"
+
 }

--- a/flutter/example/android/app/build.gradle
+++ b/flutter/example/android/app/build.gradle
@@ -75,5 +75,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    implementation "com.coinbase:coinbase-wallet-sdk:0.1.0"
+    implementation "com.coinbase:coinbase-wallet-sdk:0.2.1"
 }

--- a/flutter/example/android/app/src/main/kotlin/xyz/tribes/coinbase/coinbase_wallet_sdk_flutter_example/MainActivity.kt
+++ b/flutter/example/android/app/src/main/kotlin/xyz/tribes/coinbase/coinbase_wallet_sdk_flutter_example/MainActivity.kt
@@ -21,11 +21,6 @@ class MainActivity: FlutterActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-//        launcher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-//            val uri = result.data?.data ?: return@registerForActivityResult
-//            client.handleResponse(uri)
-//        }
     }
 
 }

--- a/flutter/example/ios/Podfile
+++ b/flutter/example/ios/Podfile
@@ -31,7 +31,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'CoinbaseWalletSDK', '0.2.1' # :path => '/Users/hish/Developer/3rd-party/coinbase-wallet-sdk'
+  pod 'CoinbaseWalletSDK', '0.2.1'
 end
 
 post_install do |installer|

--- a/flutter/example/ios/Podfile
+++ b/flutter/example/ios/Podfile
@@ -31,7 +31,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'CoinbaseWalletSDK', '0.1.0' # :path => '/Users/hish/Developer/3rd-party/coinbase-wallet-sdk'
+  pod 'CoinbaseWalletSDK', '0.2.1' # :path => '/Users/hish/Developer/3rd-party/coinbase-wallet-sdk'
 end
 
 post_install do |installer|

--- a/flutter/example/ios/Podfile.lock
+++ b/flutter/example/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - coinbase_wallet_sdk_flutter (0.0.1):
     - CoinbaseWalletSDK
     - Flutter
-  - CoinbaseWalletSDK (0.1.0)
+  - CoinbaseWalletSDK (0.2.1)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
   - coinbase_wallet_sdk_flutter (from `.symlinks/plugins/coinbase_wallet_sdk_flutter/ios`)
-  - CoinbaseWalletSDK (= 0.1.0)
+  - CoinbaseWalletSDK (= 0.2.1)
   - Flutter (from `Flutter`)
 
 SPEC REPOS:
@@ -22,9 +22,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   coinbase_wallet_sdk_flutter: f78895cdef9fd4d8b4dfb6577e34db5248071896
-  CoinbaseWalletSDK: 60d61fce1842e2b8dd567b38d4890a7052a9be4a
+  CoinbaseWalletSDK: 5e4a78b4ce64c2de5ac1ac84aab0d58d007408d2
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
 
-PODFILE CHECKSUM: 762999d2e05684fa139f8d359a700bba79f6a0fe
+PODFILE CHECKSUM: f40784f3e580cb2f82929caad98df86315be53af
 
 COCOAPODS: 1.11.3

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -27,7 +27,7 @@ class _MyAppState extends State<MyApp> {
     CoinbaseWalletSDK.shared.configure(
       Configuration(
         ios: IOSConfiguration(
-          host: Uri.parse('https://wallet.coinbase.com/wsegue'),
+          host: Uri.parse('cbwallet://wsegue'),
           callback: Uri.parse('tribesxyzsample://mycallback'),
         ),
         android: AndroidConfiguration(

--- a/flutter/ios/Classes/SwiftCoinbaseWalletSdkFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftCoinbaseWalletSdkFlutterPlugin.swift
@@ -59,6 +59,7 @@ public class SwiftCoinbaseWalletSdkFlutterPlugin: NSObject, FlutterPlugin {
         }
         
         CoinbaseWalletSDK.configure(host: hostURL,callback: callbackURL)
+        
         result(SwiftCoinbaseWalletSdkFlutterPlugin.success)
     }
     
@@ -69,8 +70,13 @@ public class SwiftCoinbaseWalletSdkFlutterPlugin: NSObject, FlutterPlugin {
             actions = try JSONDecoder().decode([Action].self, from: jsonData)
         }
         
-        CoinbaseWalletSDK.shared.initiateHandshake(initialActions: actions) { responseResult in
-            self.handleResponse(code: "initiateHandshake", responseResult: responseResult, result: result)
+        CoinbaseWalletSDK.shared.initiateHandshake(initialActions: actions) { responseResult, account in
+            self.handleResponse(
+                code: "initiateHandshake",
+                responseResult: responseResult,
+                account: account,
+                result: result
+            )
         }
     }
     
@@ -86,7 +92,12 @@ public class SwiftCoinbaseWalletSdkFlutterPlugin: NSObject, FlutterPlugin {
         let request = try JSONDecoder().decode(Request.self, from: jsonData)
         
         CoinbaseWalletSDK.shared.makeRequest(request) { responseResult in
-            self.handleResponse(code: "makeRequest", responseResult: responseResult, result: result)
+            self.handleResponse(
+                code: "makeRequest",
+                responseResult: responseResult,
+                account: nil,
+                result: result
+            )
         }
     }
     
@@ -101,7 +112,12 @@ public class SwiftCoinbaseWalletSdkFlutterPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func handleResponse(code: String, responseResult: ResponseResult, result: @escaping FlutterResult) {
+    private func handleResponse(
+        code: String,
+        responseResult: ResponseResult,
+        account: Account?,
+        result: @escaping FlutterResult
+    ) {
         do {
             switch responseResult {
             case .success(let returnValues):
@@ -109,7 +125,11 @@ public class SwiftCoinbaseWalletSdkFlutterPlugin: NSObject, FlutterPlugin {
                 returnValues.content.forEach { it in
                     switch it {
                     case .result(let value):
-                        toFlutter.append(["result": ["value": value]])
+                        var result: [String: Any] = ["value": value]
+                        if let account = account {
+                            result["account"] = account
+                        }
+                        toFlutter.append(result)
                     case .error(let code, let message):
                         toFlutter.append(["error": ["code": code, "message": message]])
                     }

--- a/flutter/ios/Classes/SwiftCoinbaseWalletSdkFlutterPlugin.swift
+++ b/flutter/ios/Classes/SwiftCoinbaseWalletSdkFlutterPlugin.swift
@@ -122,17 +122,25 @@ public class SwiftCoinbaseWalletSdkFlutterPlugin: NSObject, FlutterPlugin {
             switch responseResult {
             case .success(let returnValues):
                 var toFlutter = [[String: Any]]()
+                
                 returnValues.content.forEach { it in
+                    var response = [String: Any]()
+                    
+                    if let account = account {
+                        response["account"] = [
+                            "chain": account.chain,
+                            "networkId": account.networkId,
+                            "address": account.address
+                        ]
+                    }
                     switch it {
                     case .result(let value):
-                        var result: [String: Any] = ["value": value]
-                        if let account = account {
-                            result["account"] = account
-                        }
-                        toFlutter.append(result)
+                        response["result"] = value
                     case .error(let code, let message):
-                        toFlutter.append(["error": ["code": code, "message": message]])
+                        response["error"] = ["code": code, "message": message]
                     }
+                    
+                    toFlutter.append(response)
                 }
                 
                 let data = try JSONSerialization.data(withJSONObject: toFlutter, options: [])

--- a/flutter/lib/account.dart
+++ b/flutter/lib/account.dart
@@ -16,4 +16,12 @@ class Account {
       'address': address,
     };
   }
+
+  factory Account.fromJson(Map<String, dynamic> json) {
+    return Account(
+      chain: json['chain'] as String,
+      networkId: json['networkId'] as int,
+      address: json['address'] as String,
+    );
+  }
 }

--- a/flutter/lib/coinbase_wallet_sdk.dart
+++ b/flutter/lib/coinbase_wallet_sdk.dart
@@ -37,10 +37,17 @@ class CoinbaseWalletSDK {
     final result = await CoinbaseWalletSdkFlutterPlatform.instance
         .call('initiateHandshake', jsonEncode(actionsJson));
 
-    return (result ?? [])
-        .map((action) => ReturnValueWithAccount.fromJson(action))
+    final returnValuesWithAccounts = (result ?? [])
+        .map(
+          (e) {
+            final map = Map<String, dynamic>.from(e);
+            return ReturnValueWithAccount.fromJson(map);
+          },
+        )
         .cast<ReturnValueWithAccount>()
         .toList();
+
+    return returnValuesWithAccounts;
   }
 
   /// Send a web3 request to Coinbase Wallet app

--- a/flutter/lib/coinbase_wallet_sdk.dart
+++ b/flutter/lib/coinbase_wallet_sdk.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:coinbase_wallet_sdk_flutter/account.dart';
 import 'package:coinbase_wallet_sdk_flutter/action.dart';
 import 'package:coinbase_wallet_sdk_flutter/coinbase_wallet_sdk_flutter_platform_interface.dart';
 import 'package:coinbase_wallet_sdk_flutter/configuration.dart';
@@ -27,7 +28,7 @@ class CoinbaseWalletSDK {
   }
 
   /// Initiate the handshake with Coinbase Wallet app
-  Future<List<ReturnValue>> initiateHandshake(
+  Future<List<ReturnValueWithAccount>> initiateHandshake(
     List<Action>? initialActions,
   ) async {
     final actionsJson =
@@ -37,8 +38,8 @@ class CoinbaseWalletSDK {
         .call('initiateHandshake', jsonEncode(actionsJson));
 
     return (result ?? [])
-        .map((action) => ReturnValue.fromJson(action))
-        .cast<ReturnValue>()
+        .map((action) => ReturnValueWithAccount.fromJson(action))
+        .cast<ReturnValueWithAccount>()
         .toList();
   }
 
@@ -48,7 +49,7 @@ class CoinbaseWalletSDK {
         .call('makeRequest', jsonEncode(request.toJson()));
 
     return (result ?? [])
-        .map((action) => ReturnValue.fromJson(action))
+        .map((e) => ReturnValue.fromJson(e))
         .cast<ReturnValue>()
         .toList();
   }
@@ -60,8 +61,8 @@ class CoinbaseWalletSDK {
 
   /// Check whether CoinbaseWallet app is installed
   Future<bool> isAppInstalled() async {
-    final result = await CoinbaseWalletSdkFlutterPlatform.instance
-        .call('isAppInstalled');
+    final result =
+        await CoinbaseWalletSdkFlutterPlatform.instance.call('isAppInstalled');
     return result ?? false;
   }
 
@@ -81,5 +82,25 @@ class CoinbaseWalletSDK {
     }
     await CoinbaseWalletSdkFlutterPlatform.instance
         .call('configure', configuration.toJson());
+  }
+}
+
+class ReturnValueWithAccount {
+  final String? value;
+  final ReturnValueError? error;
+  final Account? account;
+
+  ReturnValueWithAccount(ReturnValue returnValue, this.account)
+      : value = returnValue.value,
+        error = returnValue.error;
+
+  factory ReturnValueWithAccount.fromJson(Map<String, dynamic> json) {
+    final account = json['account'];
+    return ReturnValueWithAccount(
+      ReturnValue.fromJson(json),
+      account == null
+          ? null
+          : Account.fromJson(Map<String, dynamic>.from(account)),
+    );
   }
 }

--- a/flutter/lib/return_value.dart
+++ b/flutter/lib/return_value.dart
@@ -10,7 +10,7 @@ class ReturnValue {
   factory ReturnValue.fromJson(Map<String, dynamic> json) {
     final error = json['error'];
     return ReturnValue(
-      value: json['value'] as String?,
+      value: json['result'] as String?,
       error: error == null
           ? null
           : ReturnValueError.fromJson(Map<String, dynamic>.from(error)),

--- a/flutter/lib/return_value.dart
+++ b/flutter/lib/return_value.dart
@@ -8,13 +8,12 @@ class ReturnValue {
   });
 
   factory ReturnValue.fromJson(Map<String, dynamic> json) {
-    final result = json['result'];
     final error = json['error'];
     return ReturnValue(
-      value: result == null ? null : result['value'] as String,
+      value: json['value'] as String?,
       error: error == null
           ? null
-          : ReturnValueError.fromJson(error as Map<String, dynamic>),
+          : ReturnValueError.fromJson(Map<String, dynamic>.from(error)),
     );
   }
 }


### PR DESCRIPTION
Recently there was a new breaking change that passed `Account` instead of `String` when requesting an account in the initial handshake. This patch fixes Flutter API to work correctly with new account changes.