### PR TITLE
Update compile SDK of client app for android

### DIFF
--- a/android/example/build.gradle
+++ b/android/example/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     signingConfigs {
         development {
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.coinbase.android.beta"
         minSdk 23
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
### _Summary_
Update compile SDK of client app for android

* ktx 1.9.0 is dependent on compile sdk version 33

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

automerge=true