### PR TITLE
Update iOS deployment target to 13.0

### DIFF
--- a/react-native/ios/CoinbaseWalletSDKExpo.podspec
+++ b/react-native/ios/CoinbaseWalletSDKExpo.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '12.0'
+  s.platform       = :ios, '13.0'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/coinbase/wallet-mobile-sdk' }
   s.static_framework = true


### PR DESCRIPTION
### _Summary_

Expo SDK 47 now requires the iOS deployment target to be 13.0 minimum: https://blog.expo.dev/expo-sdk-47-a0f6f5c038af

### _How did you test your changes?_

I haven't tested the change