### PR TITLE
Use unique uuid for ResponseMessage

### DIFF
--- a/react-native/host/package.json
+++ b/react-native/host/package.json
@@ -136,6 +136,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "events": "^3.3.0",
-    "react-native-url-polyfill": "^1.3.0"
+    "react-native-url-polyfill": "^1.3.0",
+    "react-native-uuid": "^2.0.1"
   }
 }

--- a/react-native/host/src/response/response.ts
+++ b/react-native/host/src/response/response.ts
@@ -6,6 +6,7 @@ import { isHandshakeAction, RequestAction } from '../action/action';
 import { MWPHostModule } from '../native-module/MWPHostNativeModule';
 import type { RequestMessage } from '../request/request';
 import { getSession, SecureStorage, updateSessions } from '../sessions/sessions';
+import { uuidV4 } from '../utils/uuid';
 import { URL } from 'react-native-url-polyfill';
 import { Buffer } from 'buffer';
 
@@ -124,7 +125,7 @@ export async function sendResponse(
   const response: ResponseMessage = {
     version: session.version ?? '0', // TODO: Should this be version of sdk in host library?
     sender: session.sessionPublicKey,
-    uuid: session.sessionId, // TODO: Should this be a unique id?
+    uuid: uuidV4(),
     callbackUrl: session.dappURL,
     timestamp: Date.now(),
     content: {
@@ -177,7 +178,7 @@ export async function sendError(description: string, message: RequestMessage | D
   const response: ResponseMessage = {
     version: message.version,
     sender: message.sender,
-    uuid: message.uuid, // TODO: Should this be a unique uuid?
+    uuid: uuidV4(),
     callbackUrl: message.callbackUrl,
     timestamp: Date.now(),
     content: {

--- a/react-native/host/src/utils/uuid.ts
+++ b/react-native/host/src/utils/uuid.ts
@@ -1,0 +1,9 @@
+import UUID from 'react-native-uuid';
+
+export function uuidV4(): string {
+  const uuid = UUID.v4();
+  if (typeof uuid === 'string') {
+    return uuid;
+  }
+  return UUID.unparse(uuid);
+}

--- a/react-native/host/yarn.lock
+++ b/react-native/host/yarn.lock
@@ -6030,6 +6030,11 @@ react-native-url-polyfill@^1.3.0:
   dependencies:
     whatwg-url-without-unicode "8.0.0-3"
 
+react-native-uuid@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
+  integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
+
 react-native@0.70.6:
   version "0.70.6"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.70.6.tgz#d692f8b51baffc28e1a8bc5190cdb779de937aa8"


### PR DESCRIPTION
### _Summary_
* Add `react-native-uuid` dependency: https://www.npmjs.com/package/react-native-uuid
* Update ResponseMessage encoding to use unique uuid for each response instead of returning the client message uuid

### _How did you test your changes?_
Tested manually
