### PR TITLE
Use mobile sdk version in ResponseMessage

### DIFF
--- a/react-native/host/android/build.gradle
+++ b/react-native/host/android/build.gradle
@@ -33,14 +33,20 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['MobileWalletProtocolHost_' + name]).toInteger()
 }
 
+// Mobile SDK Version
+def sdk_version = "1.0.4"
+
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
+
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+    buildConfigField "String", "MOBILE_SDK_VERSION", "\"${sdk_version}\""
   }
+
   buildTypes {
     release {
       minifyEnabled false
@@ -135,7 +141,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "com.coinbase:coinbase-wallet-sdk:1.0.3"
+  implementation "com.coinbase:coinbase-wallet-sdk:$sdk_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
   implementation 'com.google.crypto.tink:tink-android:1.6.1'
   implementation 'androidx.core:core-ktx:1.8.0'

--- a/react-native/host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/MobileWalletProtocolHostModule.kt
+++ b/react-native/host/android/src/main/java/com/coinbase/mobilewalletprotocolhost/MobileWalletProtocolHostModule.kt
@@ -27,6 +27,12 @@ class MobileWalletProtocolHostModule(reactContext: ReactApplicationContext) : Re
     }
 
     @ReactMethod
+    fun getSdkVersion(promise: Promise) {
+        // TODO: Get SDK Version from Client SDK
+        promise.resolve(BuildConfig.MOBILE_SDK_VERSION)
+    }
+
+    @ReactMethod
     fun generateKeyPair(promise: Promise) {
         val sessionKeyPair = EllipticCurves.generateKeyPair(EllipticCurves.CurveType.NIST_P256)
         val keyMap = Arguments.createMap().apply {

--- a/react-native/host/example/ios/Podfile.lock
+++ b/react-native/host/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
-  - CoinbaseWalletSDK/Client (1.0.3)
-  - CoinbaseWalletSDK/Host (1.0.3):
+  - CoinbaseWalletSDK/Client (1.0.4)
+  - CoinbaseWalletSDK/Host (1.0.4):
     - CoinbaseWalletSDK/Client
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.70.6)
@@ -81,7 +81,7 @@ PODS:
   - MMKV (1.2.14):
     - MMKVCore (~> 1.2.14)
   - MMKVCore (1.2.14)
-  - mobile-wallet-protocol-host (0.1.0):
+  - mobile-wallet-protocol-host (0.1.1):
     - CoinbaseWalletSDK/Host
     - React-Core
   - OpenSSL-Universal (1.1.1100)
@@ -314,6 +314,12 @@ PODS:
   - react-native-mmkv (2.5.1):
     - MMKV (>= 1.2.13)
     - React-Core
+  - react-native-safe-area-context (4.4.1):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - ReactCommon/turbomodule/core
   - React-perflogger (0.70.6)
   - React-RCTActionSheet (0.70.6):
     - React-Core/RCTActionSheetHeaders (= 0.70.6)
@@ -434,6 +440,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -516,6 +523,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   react-native-mmkv:
     :path: "../node_modules/react-native-mmkv"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
   React-RCTActionSheet:
@@ -546,7 +555,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  CoinbaseWalletSDK: 304652e641f9fb265082ff3f3e8c4f45e695e947
+  CoinbaseWalletSDK: ea1f37512bbc69ebe07416e3b29bf840f5cc3152
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 48289402952f4f7a4e235de70a9a590aa0b79ef4
   FBReactNativeSpec: dd1186fd05255e3457baa2f4ca65e94c2cd1e3ac
@@ -565,7 +574,7 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MMKV: 9c4663aa7ca255d478ff10f2f5cb7d17c1651ccd
   MMKVCore: 89f5c8a66bba2dcd551779dea4d412eeec8ff5bb
-  mobile-wallet-protocol-host: bdadbdcc8026786fea4b3cd95521bea220ba1429
+  mobile-wallet-protocol-host: 53e0839f1539a583bbaea2b3f89196f48f010bee
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: e1866f61af7049eb3d8e08e8b133abd38bc1ca7a
@@ -583,6 +592,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 60769e5a0a6d4b32294a2456077f59d0266f9a8b
   React-logger: 1623c216abaa88974afce404dc8f479406bbc3a0
   react-native-mmkv: 69b9c003f10afdd01addf7c6ee784ce42ee2eff3
+  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   React-perflogger: 8c79399b0500a30ee8152d0f9f11beae7fc36595
   React-RCTActionSheet: 7316773acabb374642b926c19aef1c115df5c466
   React-RCTAnimation: 5341e288375451297057391227f691d9b2326c3d

--- a/react-native/host/ios/MobileWalletProtocolHost.m
+++ b/react-native/host/ios/MobileWalletProtocolHost.m
@@ -18,6 +18,9 @@ RCT_EXTERN_METHOD(encodeResponse:(NSDictionary*)dictionary
 RCT_EXTERN_METHOD(generateKeyPair:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getSdkVersion:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
     return NO;

--- a/react-native/host/ios/MobileWalletProtocolHost.swift
+++ b/react-native/host/ios/MobileWalletProtocolHost.swift
@@ -4,6 +4,16 @@ import CryptoKit
 @available(iOS 13.0, *)
 @objc(MobileWalletProtocolHost)
 class MobileWalletProtocolHost: NSObject {
+
+    @objc(getSdkVersion:rejecter:)
+    public func getSdkVersion(
+        resolve: RCTPromiseResolveBlock,
+        reject: RCTPromiseRejectBlock
+    ) {
+        // TODO: Get SDK Version from Client SDK
+        resolve("1.0.4")
+    }
+
     @objc(generateKeyPair:rejecter:)
     public func generateKeyPair(
         resolve: RCTPromiseResolveBlock,

--- a/react-native/host/src/native-module/MWPHostNativeModule.ts
+++ b/react-native/host/src/native-module/MWPHostNativeModule.ts
@@ -87,6 +87,8 @@ type UnencodedResponse = {
 };
 
 type MWPHostNativeModule = {
+  getSdkVersion: () => Promise<string>;
+
   generateKeyPair: () => Promise<GenerateKeyPairResult>;
 
   decodeRequest: (

--- a/react-native/host/src/response/response.ts
+++ b/react-native/host/src/response/response.ts
@@ -122,8 +122,10 @@ export async function sendResponse(
     },
   ]);
 
+  const sdkVersion = await MWPHostModule.getSdkVersion();
+
   const response: ResponseMessage = {
-    version: session.version ?? '0', // TODO: Should this be version of sdk in host library?
+    version: sdkVersion,
     sender: session.sessionPublicKey,
     uuid: uuidV4(),
     callbackUrl: session.dappURL,
@@ -175,8 +177,10 @@ export async function sendResponse(
 }
 
 export async function sendError(description: string, message: RequestMessage | DecodedRequest) {
+  const sdkVersion = await MWPHostModule.getSdkVersion();
+
   const response: ResponseMessage = {
-    version: message.version,
+    version: sdkVersion,
     sender: message.sender,
     uuid: uuidV4(),
     callbackUrl: message.callbackUrl,


### PR DESCRIPTION
### _Summary_
Uses the host's mobile sdk version in ResponseMessage instead of returning the sdk version of the incoming request's version 

### _How did you test your changes?_
Tested manually
