### PR TITLE
Add responseId to encrypted response object

### DIFF
--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/CoinbaseWalletSDK.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/CoinbaseWalletSDK.kt
@@ -255,9 +255,14 @@ class CoinbaseWalletSDK internal constructor(
         }
 
         fun handleResponse(uri: Uri): Boolean {
-            val requestId = checkNotNull(MessageConverter.getRequestIdFromResponse(uri)) { "Callback not found" }
-            val host = TaskManager.findRequestId(requestId) ?: return false
-            return instances[host]?.handleResponse(uri) == true
+            try {
+                val requestId = checkNotNull(MessageConverter.getRequestIdFromResponse(uri)) { "requestId not found" }
+                val host = TaskManager.findRequestId(requestId) ?: return false
+                return instances[host]?.handleResponse(uri) ?: false
+            } catch (e: IllegalStateException) {
+                // Fallback to CB Wallet instance
+                return instances[DefaultWallets.coinbaseWallet.url]?.handleResponse(uri) ?: false
+            }
         }
     }
 }

--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/Wallet.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/Wallet.kt
@@ -14,14 +14,14 @@ data class Wallet(
 }
 
 object DefaultWallets {
-    private val coinbaseWallet = Wallet(
+    val coinbaseWallet = Wallet(
         name = "Coinbase Wallet",
         iconUrl = "https://play-lh.googleusercontent.com/wrgUujbq5kbn4Wd4tzyhQnxOXkjiGqq39N4zBvCHmxpIiKcZw_Pb065KTWWlnoejsg",
         packageName = "org.toshi",
         url = "cbwallet://wsegue"
     )
 
-    private val coinbaseRetail = Wallet(
+    val coinbaseRetail = Wallet(
         name = "Coinbase",
         iconUrl = "https://play-lh.googleusercontent.com/PjoJoG27miSglVBXoXrxBSLveV6e3EeBPpNY55aiUUBM9Q1RCETKCOqdOkX2ZydqVf0",
         packageName = "org.toshi.debugger",

--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/message/MessageConverter.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/message/MessageConverter.kt
@@ -82,7 +82,15 @@ object MessageConverter {
         val encodedMessage = requireNotNull(uri.getQueryParameter("p"))
         val messageJsonString = String(Base64.decode(encodedMessage))
         val messageJson = JSON.parseToJsonElement(messageJsonString)
-        return messageJson.jsonObject["uuid"]?.jsonPrimitive?.content
+
+        //TODO: Create `decodeWithoutDecryption` function
+        messageJson.jsonObject["content"]?.let { content ->
+            content.jsonObject["response"]?.let { response ->
+                return response.jsonObject["requestId"]?.jsonPrimitive?.content
+            }
+        }
+
+        return null
     }
 
     private fun getSharedSecret(

--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/message/response/EncryptedResponse.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/message/response/EncryptedResponse.kt
@@ -3,4 +3,7 @@ package com.coinbase.android.nativesdk.message.response
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class EncryptedResponse(val data: String)
+internal class EncryptedResponse(
+    val requestId: String,
+    val data: String
+)

--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/message/response/ResponseSerializer.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/message/response/ResponseSerializer.kt
@@ -37,7 +37,12 @@ class ResponseSerializer(
                             secret = sharedSecret ?: throw CoinbaseWalletSDKError.MissingSharedSecret,
                             message = formatter.encodeToString(value)
                         )
-                        formatter.encodeToJsonElement(EncryptedResponse(encryptedData))
+                        formatter.encodeToJsonElement(
+                            EncryptedResponse(
+                                requestId = value.requestId,
+                                data = encryptedData
+                            )
+                        )
                     } else {
                         formatter.encodeToJsonElement(value)
                     }


### PR DESCRIPTION
### _Summary_
* Add responseId to encrypted response object
* Add fallback to CB Wallet if requestId is not present

### _How did you test your changes?_
Manually tested that responseId is present on encrypted response message
```json
  {
    "uuid": "hello-world",
    "version": "1.0.0",
    "sender": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOsVDIG7VzE2oqzcSCgbK/NgBnA6FyPTHZuYVk+R53SrP5j5/1sYkwzD7PQzbXn3d3U0DeH74VvGEH8yCux0nPw==",
    "content": {
      "response": {
        "requestId": "my-request-id",
        "data": "SQMffejbJhOPwU/pCAh3VpclIDH5k2T+Ex19YDA3dBguv1GXy5ZOzK5E/1HyX2iLyb3Od/XrvwbX9xoe369vU8VGuuYjZsxkfBg3AXye/PguUccydkv4I7KSyROzkxCVFkMRfLyFsIbhZ8TetfklCrf85ihwFcfW9fVAUzWkuuiFpJsNgonQSWIqdMrQNyNU19VfCNr/jGb7xw1ZHdA="
      }
    },
    "timestamp": 1670352972555,
    "callbackUrl": "https://myapp.com"
  }
```