### PR TITLE
Update active message to null when non-optional request is rejected

### DIFF
--- a/react-native/host/example/src/ActionsScreen.tsx
+++ b/react-native/host/example/src/ActionsScreen.tsx
@@ -20,16 +20,19 @@ export function ActionsScreen({ message }: ActionsScreenProps) {
     return null;
   }
 
+  const nextAction = (shouldContinue: boolean) => {
+    // Iterate to next action if host library tells us to proceed
+    if (shouldContinue) {
+      setActiveIndex((i) => i + 1);
+    }
+  };
+
   if (isHandshakeAction(activeAction)) {
-    return (
-      <HandshakeActionItem action={activeAction} onHandled={() => setActiveIndex((i) => i + 1)} />
-    );
+    return <HandshakeActionItem action={activeAction} onHandled={nextAction} />;
   }
 
   if (isEthereumAction(activeAction)) {
-    return (
-      <RequestActionItem action={activeAction} onHandled={() => setActiveIndex((i) => i + 1)} />
-    );
+    return <RequestActionItem action={activeAction} onHandled={nextAction} />;
   }
 
   return (

--- a/react-native/host/example/src/HandshakeActionItem.tsx
+++ b/react-native/host/example/src/HandshakeActionItem.tsx
@@ -9,7 +9,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type HandshakeItemProps = {
   action: HandshakeAction;
-  onHandled: () => void;
+  onHandled: (shouldContinue: boolean) => void;
 };
 
 export function HandshakeActionItem({ action, onHandled }: HandshakeItemProps) {
@@ -31,13 +31,13 @@ export function HandshakeActionItem({ action, onHandled }: HandshakeItemProps) {
   }, [fetchClientAppMetadata, isClientAppVerified]);
 
   const approve = async () => {
-    await approveHandshake(metadata);
-    onHandled();
+    const proceed = await approveHandshake(metadata);
+    onHandled(proceed);
   };
 
   const reject = async () => {
-    await rejectHandshake('User rejected handshake');
-    onHandled();
+    const proceed = await rejectHandshake('User rejected handshake');
+    onHandled(proceed);
   };
 
   return (

--- a/react-native/host/example/src/RequestActionItem.tsx
+++ b/react-native/host/example/src/RequestActionItem.tsx
@@ -8,7 +8,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type RequestItemProps = {
   action: EthereumRequestAction;
-  onHandled: () => void;
+  onHandled: (shouldContinue: boolean) => void;
 };
 
 export function RequestActionItem({ action, onHandled }: RequestItemProps) {
@@ -17,13 +17,13 @@ export function RequestActionItem({ action, onHandled }: RequestItemProps) {
   const { approveAction, rejectAction } = useMobileWalletProtocolHost();
 
   const approve = async () => {
-    await approveAction(action, { value: '0xdeadbeef' });
-    onHandled();
+    const proceed = await approveAction(action, { value: '0xdeadbeef' });
+    onHandled(proceed);
   };
 
   const reject = async () => {
-    await rejectAction(action, { code: 4001, message: 'User rejected request' });
-    onHandled();
+    const proceed = await rejectAction(action, { code: 4001, message: 'User rejected request' });
+    onHandled(proceed);
   };
 
   return (

--- a/react-native/host/src/provider/MobileWalletProtocolProvider.tsx
+++ b/react-native/host/src/provider/MobileWalletProtocolProvider.tsx
@@ -34,10 +34,10 @@ type MWPHostContextType = {
   handleRequestUrl: (url: string) => Promise<boolean>;
   fetchClientAppMetadata: () => Promise<AppMetadata | null>;
   isClientAppVerified: () => Promise<boolean>;
-  approveHandshake: (metadata: AppMetadata | null) => Promise<void>;
-  rejectHandshake: (description: string) => Promise<void>;
-  approveAction: (action: RequestAction, result: ResultValue) => Promise<void>;
-  rejectAction: (action: RequestAction, error: ErrorValue) => Promise<void>;
+  approveHandshake: (metadata: AppMetadata | null) => Promise<boolean>;
+  rejectHandshake: (description: string) => Promise<boolean>;
+  approveAction: (action: RequestAction, result: ResultValue) => Promise<boolean>;
+  rejectAction: (action: RequestAction, error: ErrorValue) => Promise<boolean>;
 };
 
 type MWPHostProviderProps = {
@@ -144,7 +144,7 @@ export function MobileWalletProtocolProvider({
   }, [activeMessage?.actions]);
 
   const approveHandshake = useCallback(
-    async (metadata: AppMetadata | null) => {
+    async (metadata: AppMetadata | null): Promise<boolean> => {
       if (!activeMessage) {
         throw new Error('No message found');
       }
@@ -173,25 +173,29 @@ export function MobileWalletProtocolProvider({
       if (shouldRespondToClient(actionToResponseMap, activeMessage)) {
         await sendResponse(actionToResponseMap, activeMessage, secureStorage);
         updateActiveMessage(null);
+        return false;
       }
+
+      return true;
     },
     [activeMessage, secureStorage, updateActiveMessage],
   );
 
   const rejectHandshake = useCallback(
-    async (description: string) => {
+    async (description: string): Promise<boolean> => {
       if (!activeMessage) {
         throw new Error('No message found');
       }
 
       await sendError(description, activeMessage);
       updateActiveMessage(null);
+      return false;
     },
     [activeMessage, updateActiveMessage],
   );
 
   const approveAction = useCallback(
-    async (action: RequestAction, result: ResultValue) => {
+    async (action: RequestAction, result: ResultValue): Promise<boolean> => {
       if (!activeMessage) {
         throw new Error('No message found');
       }
@@ -201,13 +205,16 @@ export function MobileWalletProtocolProvider({
       if (shouldRespondToClient(actionToResponseMap, activeMessage)) {
         await sendResponse(actionToResponseMap, activeMessage, secureStorage);
         updateActiveMessage(null);
+        return false;
       }
+
+      return true;
     },
     [activeMessage, secureStorage, updateActiveMessage],
   );
 
   const rejectAction = useCallback(
-    async (action: RequestAction, error: ErrorValue) => {
+    async (action: RequestAction, error: ErrorValue): Promise<boolean> => {
       if (!activeMessage) {
         throw new Error('No message found');
       }
@@ -218,11 +225,15 @@ export function MobileWalletProtocolProvider({
         if (shouldRespondToClient(actionToResponseMap, activeMessage)) {
           await sendResponse(actionToResponseMap, activeMessage, secureStorage);
           updateActiveMessage(null);
+          return false;
         }
       } else {
         await sendResponse(actionToResponseMap, activeMessage, secureStorage);
         updateActiveMessage(null);
+        return false;
       }
+
+      return true;
     },
     [activeMessage, secureStorage, updateActiveMessage],
   );

--- a/react-native/host/src/provider/MobileWalletProtocolProvider.tsx
+++ b/react-native/host/src/provider/MobileWalletProtocolProvider.tsx
@@ -221,6 +221,7 @@ export function MobileWalletProtocolProvider({
         }
       } else {
         await sendResponse(actionToResponseMap, activeMessage, secureStorage);
+        updateActiveMessage(null);
       }
     },
     [activeMessage, secureStorage, updateActiveMessage],


### PR DESCRIPTION
### _Summary_
* update active message to null when consumer rejects a non-optional action
* returns a boolean value from `approve` and `reject` functions telling the consumer whether to continue looping through the list of actions on a message

### _How did you test your changes?_
Tested manually
