### PR TITLE
Expose active session object from host provider & misc fixes

### DIFF
--- a/react-native/host/src/events/events.ts
+++ b/react-native/host/src/events/events.ts
@@ -49,7 +49,7 @@ type SessionAddedEvent = {
 };
 
 // Response Encoding
-type ResponseEventParams = {
+export type ResponseEventParams = {
   callbackUrl: string;
   appName: string;
   appId: string;
@@ -72,7 +72,7 @@ type EncodeResponseFailureEvent = {
 };
 
 // Respond to client
-type SendSuccessResponseEvent = {
+export type SendSuccessResponseEvent = {
   name: 'send_success_response';
   params: {
     requestType: 'handshake' | 'request';
@@ -82,7 +82,7 @@ type SendSuccessResponseEvent = {
   };
 };
 
-type SendFailureResponseEvent = {
+export type SendFailureResponseEvent = {
   name: 'send_failure_response';
   params: {
     requestType: 'handshake' | 'request';
@@ -90,6 +90,26 @@ type SendFailureResponseEvent = {
     callbackUrl: string;
     appName?: string;
     appId?: string;
+  };
+};
+
+type RequestStartedEvent = {
+  name: 'request_started';
+  params: {
+    requestType: 'handshake' | 'request';
+    callbackUrl: string;
+    sdkVersion: string;
+    appName?: string;
+    appId?: string;
+  };
+};
+
+type ResponseHandledEvent = {
+  name: 'response_handled';
+  params: {
+    requestType: 'handshake' | 'request';
+    callbackUrl: string;
+    sdkVersion: string;
   };
 };
 
@@ -104,7 +124,9 @@ type MWPEvent =
   | EncodeResponseSuccessEvent
   | EncodeResponseFailureEvent
   | SendSuccessResponseEvent
-  | SendFailureResponseEvent;
+  | SendFailureResponseEvent
+  | RequestStartedEvent
+  | ResponseHandledEvent;
 
 const diagnosticLogger = new EventEmitter();
 

--- a/react-native/host/src/provider/MobileWalletProtocolProvider.tsx
+++ b/react-native/host/src/provider/MobileWalletProtocolProvider.tsx
@@ -87,6 +87,15 @@ export function MobileWalletProtocolProvider({
       }
 
       if ('handshake' in decoded.content) {
+        diagnosticLog({
+          name: 'request_started',
+          params: {
+            requestType: 'handshake',
+            callbackUrl: decoded.callbackUrl,
+            sdkVersion: decoded.version,
+          },
+        });
+
         const message = mapHandshakeToRequest(decoded.content.handshake, decoded);
         updateActiveMessage(message, null);
         return { success: true };
@@ -133,6 +142,17 @@ export function MobileWalletProtocolProvider({
             },
           };
         }
+
+        diagnosticLog({
+          name: 'request_started',
+          params: {
+            requestType: 'request',
+            callbackUrl: decoded.callbackUrl,
+            sdkVersion: decoded.version,
+            appId: session.dappId,
+            appName: session.dappName,
+          },
+        });
 
         const decrypted = await decryptRequest(url, session);
         const message = mapDecryptedContentToRequest(decrypted.content.request, decoded);


### PR DESCRIPTION
### _Summary_
* Expose active session object from host provider
* Change signature of `handleRequestUrl` function to return error cases for invalid session. The host library also does not automatically respond to this error.
* Expose new function `respondFailureToClient` that can be used by the host app to return an error to the client app
* Reorder emitted events so `send_success_response` and `send_failure_response` are emitted after `encode_response_success`
* Add `request_started` and `response_handled` events

### _How did you test your changes?_

Manually
