### PR TITLE
Gate call to getAndroidIntentUrl to Android

### DIFF
--- a/react-native/host/example/ios/Podfile.lock
+++ b/react-native/host/example/ios/Podfile.lock
@@ -81,7 +81,7 @@ PODS:
   - MMKV (1.2.14):
     - MMKVCore (~> 1.2.14)
   - MMKVCore (1.2.14)
-  - mobile-wallet-protocol-host (0.1.1):
+  - mobile-wallet-protocol-host (0.1.2):
     - CoinbaseWalletSDK/Host
     - React-Core
   - OpenSSL-Universal (1.1.1100)
@@ -574,7 +574,7 @@ SPEC CHECKSUMS:
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MMKV: 9c4663aa7ca255d478ff10f2f5cb7d17c1651ccd
   MMKVCore: 89f5c8a66bba2dcd551779dea4d412eeec8ff5bb
-  mobile-wallet-protocol-host: 53e0839f1539a583bbaea2b3f89196f48f010bee
+  mobile-wallet-protocol-host: 022a421565dbd04131048b4527e21d71e47e1676
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: e1866f61af7049eb3d8e08e8b133abd38bc1ca7a

--- a/react-native/host/src/action/action.ts
+++ b/react-native/host/src/action/action.ts
@@ -4,6 +4,8 @@ export type HandshakeAction = {
   kind: 'handshake';
   appId: string;
   callback: string;
+  appName?: string;
+  appIconUrl?: string;
 };
 
 export type RequestAction = {

--- a/react-native/host/src/native-module/MWPHostNativeModule.ts
+++ b/react-native/host/src/native-module/MWPHostNativeModule.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 type GenerateKeyPairResult = {
   publicKey: string;
@@ -116,4 +116,11 @@ type MWPHostNativeModule = {
 };
 
 export const MWPHostModule = NativeModules.MobileWalletProtocolHost as MWPHostNativeModule;
-export const getAndroidIntentUrl = MWPHostModule.getIntentUrl;
+
+export function getAndroidIntentUrl(): Promise<string | null> {
+  if (Platform.OS === 'android') {
+    return MWPHostModule.getIntentUrl();
+  } else {
+    return Promise.resolve(null);
+  }
+}

--- a/react-native/host/src/request/decoding.ts
+++ b/react-native/host/src/request/decoding.ts
@@ -12,9 +12,10 @@ export type BaseRequest = {
 };
 
 export type HandshakeContent = {
-  // TODO: Handle additional handshake params
   appId: string;
   callback: string;
+  appName?: string;
+  appIconUrl?: string;
   initialActions?: { method: string; optional: boolean; paramsJson: string }[];
 };
 

--- a/react-native/host/src/request/request.ts
+++ b/react-native/host/src/request/request.ts
@@ -25,6 +25,8 @@ export function mapHandshakeToRequest(
     kind: 'handshake',
     appId: handshake.appId,
     callback: handshake.callback,
+    appName: handshake.appName,
+    appIconUrl: handshake.appIconUrl,
   };
 
   const additionalActions: RequestAction[] =


### PR DESCRIPTION
### _Summary_
* Gate call to `getIntentUrl()` to Android. On other platforms, just return null.
* Adds optional `appName` and `appIconUrl` fields to the handshake action
* Updates pods in example host app

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
