### PR TITLE
fix wallet_switchEthereumChain and Crash where open app by deep link.

### DIFF
--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+- Changed: Type of chainId parameter on SwitchEthereumChain to string
+
 ## 1.0.6
 
 - make nullable parameters optional

--- a/flutter/example/ios/Runner/AppDelegate.swift
+++ b/flutter/example/ios/Runner/AppDelegate.swift
@@ -17,10 +17,8 @@ import CoinbaseWalletSDK
       open url: URL, 
       options: [UIApplication.OpenURLOptionsKey : Any] = [:]
     ) -> Bool {
-        if(CoinbaseWalletSDK.isConfigured){
-            if (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
-                    return true
-                }
+        if (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
+            return true
         }
         // handle other types of deep links
         return false
@@ -31,11 +29,9 @@ import CoinbaseWalletSDK
       continue userActivity: NSUserActivity, 
       restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
     ) -> Bool {
-        if(CoinbaseWalletSDK.isConfigured){
-           if let url = userActivity.webpageURL,
-              (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
-               return true
-           }
+        if let url = userActivity.webpageURL,
+           (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
+            return true
         }
         // handle other types of deep links
         return false

--- a/flutter/example/ios/Runner/AppDelegate.swift
+++ b/flutter/example/ios/Runner/AppDelegate.swift
@@ -17,8 +17,10 @@ import CoinbaseWalletSDK
       open url: URL, 
       options: [UIApplication.OpenURLOptionsKey : Any] = [:]
     ) -> Bool {
-        if (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
-            return true
+        if(CoinbaseWalletSDK.isConfigured){
+            if (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
+                    return true
+                }
         }
         // handle other types of deep links
         return false
@@ -29,9 +31,11 @@ import CoinbaseWalletSDK
       continue userActivity: NSUserActivity, 
       restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
     ) -> Bool {
-        if let url = userActivity.webpageURL,
-           (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
-            return true
+        if(CoinbaseWalletSDK.isConfigured){
+           if let url = userActivity.webpageURL,
+              (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
+               return true
+           }
         }
         // handle other types of deep links
         return false

--- a/flutter/lib/eth_web3_rpc.dart
+++ b/flutter/lib/eth_web3_rpc.dart
@@ -125,11 +125,11 @@ class SendTransaction extends Action {
 
 class SwitchEthereumChain extends Action {
   SwitchEthereumChain({
-    required int chainId,
+    required String chainId,
   }) : super(
           method: 'wallet_switchEthereumChain',
           paramsJson: jsonEncode({
-            'chainId': '$chainId',
+            'chainId': chainId,
           }),
         );
 }

--- a/flutter/lib/eth_web3_rpc.dart
+++ b/flutter/lib/eth_web3_rpc.dart
@@ -129,7 +129,7 @@ class SwitchEthereumChain extends Action {
   }) : super(
           method: 'wallet_switchEthereumChain',
           paramsJson: jsonEncode({
-            'chainId': chainId,
+            'chainId': '$chainId',
           }),
         );
 }


### PR DESCRIPTION
fix SwitchEthereumChain params .

chainId : ID of the chain to switch to, as an integer string.

see: https://coinbase.github.io/wallet-mobile-sdk/docs/client-sdk/ios-api-reference#switchethereumchain