### PR TITLE
fix: Android Build for React Native 0.73

### DIFF
--- a/react-native/client/android/build.gradle
+++ b/react-native/client/android/build.gradle
@@ -53,13 +53,16 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   namespace "expo.modules.coinbasewalletsdkexpo"


### PR DESCRIPTION
### _Summary_

With React Native 0.73 Android Gradle Plugin 8 is now supported If 8 and up the java toolchain should take care of the compatibility of java versions between dependencies

Release: https://github.com/react-native-community/discussions-and-proposals/issues/671

Fixes Error: 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 11) jvm target compatibility

Seen when building for Android

### _How did you test your changes?_

Built locally when using patch package
