### PR TITLE
Re-export types in react-native/client

### DIFF
--- a/react-native/client/src/CoinbaseWalletSDK.ts
+++ b/react-native/client/src/CoinbaseWalletSDK.ts
@@ -6,6 +6,12 @@ import {
   Result,
 } from "./CoinbaseWalletSDK.types";
 
+export {
+  Action,
+  Account,
+  ConfigurationParams,
+  Result,
+} from "./CoinbaseWalletSDK.types";
 export { WalletMobileSDKEVMProvider } from "./WalletMobileSDKEVMProvider";
 
 export function configure({


### PR DESCRIPTION
### _Summary_

Re-export types in react-native/client to make integrating more convenient for clients.

### _How did you test your changes?_

Ran `yarn build`