### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "CoinbaseWalletSDK",
-    platforms: [.iOS(.v12)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(
             name: "CoinbaseWalletSDK",


### PR DESCRIPTION
the sdk throws errors:
```'SymmetricKey' is only available in iOS 13.0 or newer```

https://github.com/MobileWalletProtocol/wallet-mobile-sdk/issues/321
