### PR TITLE
Bump Flutter SDK to 1.0.8

### DIFF
--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,12 +1,14 @@
-## Next
+## 1.0.8
 
 - Changed: Type of chainId parameter on SwitchEthereumChain to string
+- Expose ownPublicKey and peerPublicKey fields
+- Bug fixes
 
 ## 1.0.7
 
 - add AddEthereumChain action
 - expose isConnected
-  
+
 ## 1.0.6
 
 - make nullable parameters optional

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: coinbase_wallet_sdk
 description: Fluter implementation of Coinbase Wallet SDK.
-version: 1.0.7
+version: 1.0.8
 homepage: https://wallet.coinbase.com
 
 environment:


### PR DESCRIPTION
### _Summary_

* Bumps Flutter SDK to 1.0.8
* Update changelog

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

Verified that `dart pub publish --dry-run` has no errors

<!--
  Verify changes. Include relevant screenshots/videos
-->
