### PR TITLE
[Flutter] Encode public keys on Android platform

### DIFF
--- a/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
@@ -3,7 +3,6 @@ package com.coinbase.flutter.wallet_sdk
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import androidx.annotation.NonNull
 import com.coinbase.android.nativesdk.CoinbaseWalletSDK
 import com.coinbase.android.nativesdk.message.request.Account

--- a/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
@@ -25,7 +25,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
-import java.util.Base64
 
 /** CoinbaseWalletSdkFlutterPlugin */
 class CoinbaseWalletSdkFlutterPlugin : FlutterPlugin, MethodCallHandler,

--- a/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
@@ -3,6 +3,7 @@ package com.coinbase.flutter.wallet_sdk
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.annotation.NonNull
 import com.coinbase.android.nativesdk.CoinbaseWalletSDK
 import com.coinbase.android.nativesdk.message.request.Account
@@ -24,6 +25,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
+import java.util.Base64
 
 /** CoinbaseWalletSdkFlutterPlugin */
 class CoinbaseWalletSdkFlutterPlugin : FlutterPlugin, MethodCallHandler,
@@ -105,12 +107,32 @@ class CoinbaseWalletSdkFlutterPlugin : FlutterPlugin, MethodCallHandler,
     }
 
     private fun ownPublicKey(@NonNull result: Result) {
-        result.success(coinbase.ownPublicKey)
+        try {
+            val bytes = coinbase.ownPublicKey.encoded;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                result.success(bytes?.toHexString())
+            } else {
+                result.success("")
+            }
+        } catch (e: Throwable) {
+            result.success("")
+        }
     }
 
     private fun peerPublicKey(@NonNull result: Result) {
-        result.success(coinbase.peerPublicKey)
+        try {
+            val bytes = coinbase.peerPublicKey?.encoded;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                result.success(bytes?.toHexString())
+            } else {
+                result.success("")
+            }
+        } catch (e: Throwable) {
+            result.success("")
+        }
     }
+
+    private fun ByteArray.toHexString() = joinToString(separator = "") { ib -> "%02x".format(ib) }
 
     private fun configure(@NonNull call: MethodCall, @NonNull result: Result) {
         val args = call.arguments

--- a/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
+++ b/flutter/android/src/main/kotlin/com/coinbase/flutter/wallet_sdk/CoinbaseWalletSdkFlutterPlugin.kt
@@ -108,27 +108,19 @@ class CoinbaseWalletSdkFlutterPlugin : FlutterPlugin, MethodCallHandler,
 
     private fun ownPublicKey(@NonNull result: Result) {
         try {
-            val bytes = coinbase.ownPublicKey.encoded;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                result.success(bytes?.toHexString())
-            } else {
-                result.success("")
-            }
+            val bytes = coinbase.ownPublicKey.encoded
+            result.success(bytes.toHexString())
         } catch (e: Throwable) {
-            result.success("")
+            result.error("ownPublicKey", e.message, null)
         }
     }
 
     private fun peerPublicKey(@NonNull result: Result) {
         try {
-            val bytes = coinbase.peerPublicKey?.encoded;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                result.success(bytes?.toHexString())
-            } else {
-                result.success("")
-            }
+            val bytes = coinbase.peerPublicKey?.encoded
+            result.success(bytes?.toHexString())
         } catch (e: Throwable) {
-            result.success("")
+            result.error("peerPublicKey", e.message, null)
         }
     }
 


### PR DESCRIPTION
### _Summary_

`CoinbaseWalletSdkFlutterPlugin` was returning an `ECPublicKey` type in their `ownPublicKey` and `peerPublicKey` methods while expecting a String.

Correct way of doing it is same as in iOS side of things, that means, encoding the public keys to a hex string.
