### PR TITLE
Remove `universalLinksOnly` to ease URL open

### DIFF
--- a/ios/CoinbaseWalletSDK/CoinbaseWalletSDK.swift
+++ b/ios/CoinbaseWalletSDK/CoinbaseWalletSDK.swift
@@ -152,10 +152,7 @@ public final class CoinbaseWalletSDK {
             return
         }
         
-        UIApplication.shared.open(
-            url,
-            options: [.universalLinksOnly: url.isHttp]
-        ) { result in
+        UIApplication.shared.open(url) { result in
             guard result == true else {
                 onResponse(.failure(Error.openUrlFailed))
                 return


### PR DESCRIPTION
Instead of imposing restrictions within the SDK (`options: [.universalLinksOnly: ...`)
we now let the OS handle it.

If the device doesn't recognize our app's universal link, 
it will now open the link in Safari for redirection instead of just failing,
expecting branch.io to redirect to CBWallet.