### PR TITLE
AGP 8.x compatibility

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.coinbase.flutter.wallet_sdk"
     compileSdkVersion 31
 
     compileOptions {

--- a/flutter/android/src/main/AndroidManifest.xml
+++ b/flutter/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.coinbase.flutter.wallet_sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
### _Summary_

The coinbase_wallet_sdk causes a build failure because it lacks a namespace entry in its build.gradle file, which is required for compatibility with AGP 8.x. This issue prevents me from using the latest Android Gradle Plugin, which I need for other dependencies and tools in my project.

Issue https://github.com/WalletConnect/Web3ModalFlutter/issues/162

Issue https://github.com/WalletConnect/Web3ModalFlutter/issues/168

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
