### PR TITLE
iOS package version bump

### DIFF
--- a/CoinbaseWalletSDK.podspec
+++ b/CoinbaseWalletSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'CoinbaseWalletSDK'
-  s.version               = '1.1.0'
+  s.version               = '1.1.2'
   s.summary               = 'Swift implementation of WalletSegue protocol to interact with Coinbase Wallet iOS app'
   s.source                = { :git => 'https://github.com/MobileWalletProtocol/wallet-mobile-sdk.git', :tag => s.version }
   s.author                = 'Coinbase Wallet'


### PR DESCRIPTION
### _Summary_

<!--
  What changed? Link to relevant issues.
-->

android already had 1.1.1 release recently. skipping to 1.1.2

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->

 `pod lib lint`

<img width="429" alt="image" src="https://github.com/user-attachments/assets/99179082-93e4-48b7-ac3b-b5599c5c133f">
