### PR TITLE
[BW-830] KeyStore for Android SDK

### DIFF
--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/key/KeyManager.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/key/KeyManager.kt
@@ -1,5 +1,6 @@
 package com.coinbase.android.nativesdk.key
 
+import KeyStore
 import android.content.Context
 import com.google.crypto.tink.subtle.EllipticCurves
 import java.security.KeyPair
@@ -10,7 +11,7 @@ private const val OWN_KEY_PAIR_ALIAS = "own_key_pair"
 
 internal class KeyManager(appContext: Context, host: String) : IKeyManager {
 
-    private val encryptedStore: EncryptedStore
+    private val keyStore: KeyStore
     private var ownKeyPair: KeyPair? = null
 
     override val ownPublicKey: ECPublicKey
@@ -28,38 +29,38 @@ internal class KeyManager(appContext: Context, host: String) : IKeyManager {
         }
 
     override val peerPublicKey: ECPublicKey?
-        get() = encryptedStore.peerPublicKey
+        get() = keyStore.peerPublicKey
 
     init {
-        encryptedStore = EncryptedStore(
+        keyStore = KeyStore(
             fileName = "${host}_wallet_segue_key_store",
             context = appContext
         )
     }
 
     override fun storePeerPublicKey(key: ECPublicKey) {
-        encryptedStore.peerPublicKey = key
+        keyStore.peerPublicKey = key
     }
 
     override fun resetKeys() {
-        encryptedStore.reset()
+        keyStore.reset()
 
         // Create new KeyPair
         ownKeyPair = getOrCreateKeyPair(OWN_KEY_PAIR_ALIAS)
     }
 
     private fun deleteKeyPair(alias: String) {
-        encryptedStore.deleteKeyPair(alias)
+        keyStore.deleteKeyPair(alias)
     }
 
     private fun getOrCreateKeyPair(alias: String): KeyPair {
         // If no keypair, generate new key pair and save to encrypted storage
-        return encryptedStore.getKeyPair(alias) ?: generateKeyPair(alias)
+        return keyStore.getKeyPair(alias) ?: generateKeyPair(alias)
     }
 
     private fun generateKeyPair(alias: String): KeyPair {
         return EllipticCurves.generateKeyPair(EllipticCurves.CurveType.NIST_P256).also {
-            encryptedStore.saveKeyPair(alias, it)
+            keyStore.saveKeyPair(alias, it)
         }
     }
 }

--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/key/KeyStore.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/key/KeyStore.kt
@@ -1,5 +1,3 @@
-package com.coinbase.android.nativesdk.key
-
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.SharedPreferences
@@ -16,13 +14,15 @@ import java.security.KeyPair
 import java.security.KeyStore
 import java.security.interfaces.ECPublicKey
 
-private const val MAIN_KEY_ALIAS = "wallet_segue_main_key"
+private const val DEPRECATED_MAIN_KEY_ALIAS = "wallet_segue_main_key"
+private const val HAS_MIGRATED_ALIAS = "has_migrated"
+
 private const val PUBLIC_KEY_ALIAS = "public_key"
 private const val PRIVATE_KEY_ALIAS = "private_key"
 private const val PEER_PUBLIC_KEY_ALIAS = "peer_public_key"
 private const val OWN_KEY_PAIR_ALIAS = "own_key_pair"
 
-class EncryptedStore(
+class KeyStore(
     private val fileName: String,
     private val context: Context
 ) {
@@ -44,33 +44,7 @@ class EncryptedStore(
         }
 
     init {
-        storage = try {
-            getEncryptedPrefs()
-        } catch (e: Exception) {
-            when (e) {
-                is UserNotAuthenticatedException -> {
-                    throw CoinbaseWalletSDKError.UserNotAuthenticated(
-                        message = "Device needs secure lockscreen method or needs to be unlocked",
-                        cause = e
-                    )
-                }
-                else -> {
-                    // Something went wrong while retrieving the master key
-                    Log.w("CoinbaseWalletSDK.EncryptedStore", "Resetting keys due to error: ${e.message}")
-
-                    // Delete main key
-                    val ks = KeyStore.getInstance("AndroidKeyStore")
-                    ks.load(null)
-                    ks.deleteEntry(MAIN_KEY_ALIAS)
-
-                    // Clear shared prefs
-                    val prefs = context.getSharedPreferences(fileName, Context.MODE_PRIVATE)
-                    prefs.edit().clear().commit()
-
-                    getEncryptedPrefs()
-                }
-            }
-        }
+        storage = getSharedPrefs()
     }
 
     fun getKeyPair(alias: String): KeyPair? {
@@ -126,11 +100,49 @@ class EncryptedStore(
             .commit()
     }
 
+    private fun getSharedPrefs(): SharedPreferences {
+        val sharedPrefs = context.getSharedPreferences("${fileName}_raw", Context.MODE_PRIVATE)
+        val hasMigrated = sharedPrefs.getBoolean(HAS_MIGRATED_ALIAS, false)
+
+        if (!hasMigrated) {
+            try {
+                // Perform the migration
+                migrateEncryptedPrefs(sharedPrefs)
+            } catch (e: Exception) {
+                // Clear Shared Prefs State
+                sharedPrefs.edit().clear().commit()
+            } finally {
+                // Mark as migrated
+                sharedPrefs.edit().putBoolean(HAS_MIGRATED_ALIAS, true).commit()
+            }
+        }
+
+        return sharedPrefs
+    }
+
+    private fun migrateEncryptedPrefs(newPrefs: SharedPreferences) {
+        // 1. Open the old EncryptedSharedPreferences
+        val encryptedPrefs = getEncryptedPrefs()
+
+        // 2. Copy all string typed key-value pairs from encrypted prefs to new prefs in plain text
+        val allEntries = encryptedPrefs.all
+        for ((key, value) in allEntries) {
+            if (value != null) {
+                when (value) {
+                    is String  -> newPrefs.edit().putString(key, value).commit()
+                }
+            }
+        }
+
+        // 3. Clear the old EncryptedSharedPreferences
+        encryptedPrefs.edit().clear().commit()
+    }
+
     private fun getEncryptedPrefs(): SharedPreferences {
         // Create main key that secures encrypted storage
         val purposes = KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
 
-        val keyGenSpec = with(KeyGenParameterSpec.Builder(MAIN_KEY_ALIAS, purposes)) {
+        val keyGenSpec = with(KeyGenParameterSpec.Builder(DEPRECATED_MAIN_KEY_ALIAS, purposes)) {
             val keyguard = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
             if (keyguard.isDeviceSecure) {
                 setUserAuthenticationRequired(true)

--- a/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/key/KeyStore.kt
+++ b/android/walletsdk/src/main/java/com/coinbase/android/nativesdk/key/KeyStore.kt
@@ -15,7 +15,7 @@ import java.security.KeyStore
 import java.security.interfaces.ECPublicKey
 
 private const val DEPRECATED_MAIN_KEY_ALIAS = "wallet_segue_main_key"
-private const val HAS_MIGRATED_ALIAS = "has_migrated"
+private const val HAS_MIGRATED_TO_VERSION_120_ALIAS = "has_migrated_to_version_1.2.0"
 
 private const val PUBLIC_KEY_ALIAS = "public_key"
 private const val PRIVATE_KEY_ALIAS = "private_key"
@@ -102,9 +102,9 @@ class KeyStore(
 
     private fun getSharedPrefs(): SharedPreferences {
         val sharedPrefs = context.getSharedPreferences("${fileName}_raw", Context.MODE_PRIVATE)
-        val hasMigrated = sharedPrefs.getBoolean(HAS_MIGRATED_ALIAS, false)
+        val hasMigratedToVersion120 = sharedPrefs.getBoolean(HAS_MIGRATED_TO_VERSION_120_ALIAS, false)
 
-        if (!hasMigrated) {
+        if (!hasMigratedToVersion120) {
             try {
                 // Perform the migration
                 migrateEncryptedPrefs(sharedPrefs)
@@ -113,7 +113,7 @@ class KeyStore(
                 sharedPrefs.edit().clear().commit()
             } finally {
                 // Mark as migrated
-                sharedPrefs.edit().putBoolean(HAS_MIGRATED_ALIAS, true).commit()
+                sharedPrefs.edit().putBoolean(HAS_MIGRATED_TO_VERSION_120_ALIAS, true).commit()
             }
         }
 


### PR DESCRIPTION
### _Summary_

On lower Android apis, we are seeing exception thrown due to unnecessary encryption. Replacing encryptedPrefs w sharedPrefs for Android SDK, which aligns with iOS implementation, to resolve this issue.

### _How did you test your changes?_

Android 35: Verified migration works as expected, and only called once. Migrated keys work as expected.

![Screenshot 2025-01-06 at 4 07 34 PM](https://github.com/user-attachments/assets/716de1da-ad88-407d-816f-44192f62c1ce)


Android 23: TBD
