### PR TITLE
move mmkv to peerDeps

### DIFF
--- a/react-native/package.json
+++ b/react-native/package.json
@@ -31,8 +31,7 @@
     "eth-rpc-errors": "4.0.3",
     "buffer": "6.0.3",
     "bn.js": "5.2.1",
-    "events": "^3.0.0",
-    "react-native-mmkv": "^2.11.0"
+    "events": "^3.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.25",
@@ -41,6 +40,7 @@
     "expo-modules-core": "^1.1.0"
   },
   "peerDependencies": {
+    "react-native-mmkv": "*",
     "expo": "*",
     "react": "*",
     "react-native": "*"


### PR DESCRIPTION
Moving "react-native-mmkv" to peer dependencies solve the issue of having two conflicting versions of mmkv